### PR TITLE
Fix caption alignment and improve makefile

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,9 @@
+== 3.6.1 - 2025/02/07
+* Fix bug in handling of the `raggedouter' option that caused the captions to
+  be always ragged to the right.
+* Improve how makefile compiles `tex' files, ignoring the customization files
+  called `tufte-*-local.tex'.
+
 == 3.6.0 - 2023/03/20
 
 * Clean up code formatting/style.

--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,15 @@ LMKFLAGS = -outdir=samples -bibtex
 CLASSDIR =  $$(kpsewhich -var-value TEXMFHOME)/tex/latex/tufte-latex
 DOCDIR =  $$(kpsewhich -var-value TEXMFHOME)/doc/latex/tufte-latex
 
+# The [^tufte-*-local]*.tex pattern is used to exclude tufte local tex files
 test-lua:
-	latexmk $(LMKFLAGS) -lualatex -jobname=%A-lualatex *.tex
+	latexmk $(LMKFLAGS) -lualatex -jobname=%A-lualatex [^tufte-*-local]*.tex
 
 test-xe:
-	latexmk $(LMKFLAGS) -xelatex -jobname=%A-xelatex *.tex
+	latexmk $(LMKFLAGS) -xelatex -jobname=%A-xelatex [^tufte-*-local]*.tex
 
 test-pdf:
-	latexmk $(LMKFLAGS) -pdflatex -jobname=%A-pdflatex *.tex
+	latexmk $(LMKFLAGS) -pdflatex -jobname=%A-pdflatex [^tufte-*-local]*.tex
 
 test: test-lua test-xe test-pdf
 

--- a/tufte-book.cls
+++ b/tufte-book.cls
@@ -80,10 +80,10 @@
 \setcounter{tocdepth}{0}
 
 %%
-% If there is a `tufte-book-local.sty' file, load it.
+% If there is a `tufte-book-local.tex' file, load it.
 \IfFileExists{tufte-book-local.tex}{%
   \@tufte@info@noline{Loading tufte-book-local.tex}%
-  \input{tufte-book-local}%
+  \input{tufte-book-local.tex}%
 }{}
 
 %%

--- a/tufte-book.cls
+++ b/tufte-book.cls
@@ -1,6 +1,6 @@
 \NeedsTeXFormat{LaTeX2e}[1994/06/01]
 \ProvidesClass{tufte-book}
-  [2023/03/20 v3.6.0 Tufte-book class]
+  [2025/02/07 v3.6.1 Tufte-book class]
 
 %%
 % Declare we're tufte-book

--- a/tufte-common.def
+++ b/tufte-common.def
@@ -1381,7 +1381,8 @@
 % Forces the outer edge of the caption to be set ragged.  Therefore, on verso
 % pages it's ragged left, and on recto pages it's ragged right.
 \newcommand*{\@tufte@justification@caption@outer}{%
-  \ifthenelse{\boolean{@tufte@float@recto}}{%
+  \@tufte@checkoddpage%
+  \ifthenelse{\boolean{@tufte@odd@page}}{%
     \RaggedRight
   }{%
     \RaggedLeft

--- a/tufte-common.def
+++ b/tufte-common.def
@@ -2427,8 +2427,8 @@
 %%
 % If there is a `tufte-common-local.tex' file, load it up.
 \IfFileExists{tufte-common-local.tex}{%
-  \input{tufte-common-local.tex}%
   \@tufte@info@noline{Loading tufte-common-local.tex}%
+  \input{tufte-common-local.tex}%
 }{}
 
 %%

--- a/tufte-common.def
+++ b/tufte-common.def
@@ -1380,15 +1380,6 @@
 %%
 % Forces the outer edge of the caption to be set ragged.  Therefore, on verso
 % pages it's ragged left, and on recto pages it's ragged right.
-\newcommand*{\@tufte@justification@caption@outer}{%
-  \@tufte@checkoddpage%
-  \ifthenelse{\boolean{@tufte@odd@page}}{%
-    \RaggedRight
-  }{%
-    \RaggedLeft
-  }%
-}
-
 \newcommand*{\@tufte@justification@outer}{%
   \@tufte@checkoddpage%
   \ifthenelse{\boolean{@tufte@odd@page}}{%
@@ -1397,6 +1388,8 @@
     \RaggedLeft
   }%
 }
+
+\newcommand*{\@tufte@justification@caption@outer}{\@tufte@justification@outer}}
 
 %%
 % A collection of macros to be used with the new Tufte-style float

--- a/tufte-common.def
+++ b/tufte-common.def
@@ -3,7 +3,7 @@
 %% classes.
 %%
 \ProvidesFile{tufte-common.def}
-  [2023/03/20 v3.6.0 Common code for the Tufte-LaTeX styles]
+  [2025/02/07 v3.6.1 Common code for the Tufte-LaTeX styles]
 
 %%
 % The `xkeyval' package simplifies the user interface for the document class

--- a/tufte-handout.cls
+++ b/tufte-handout.cls
@@ -1,6 +1,6 @@
 \NeedsTeXFormat{LaTeX2e}[1994/06/01]
 \ProvidesClass{tufte-handout}
-  [2023/03/20 v3.6.0 Tufte-handout class]
+  [2025/02/07 v3.6.1 Tufte-handout class]
 
 %%
 % Declare we're tufte-handout

--- a/tufte-handout.cls
+++ b/tufte-handout.cls
@@ -35,8 +35,8 @@
 %%
 % If there is a `tufte-handout-local.tex' file, load it.
 \IfFileExists{tufte-handout-local.tex}{%
-  \input{tufte-handout-local}%
   \@tufte@info@noline{Loading tufte-handout-local.tex}%
+  \input{tufte-handout-local.tex}%
 }{}
 
 %%


### PR DESCRIPTION
## Makefile change
The tufte classes can be customized with help of `tufte-common-local.tex`, `tufte-book-local.tex`, and `tufte-handout-local.tex` files. The makefile as it is written would try to compile these files into pdf, which would most likely fail. This change changes makefile so it ignores these files.

Cleaned up the way those files are loaded in each class so it is more standardized.

## Marginnote caption alignment
The command that sets text alignment of captions for `marginfigure` was not working properly in cases where `twoside` option was on and `caption` was set to `raggedouter`. It uses the `@tufte@float@recto` boolean, but it seems to not work as intended and text was always ragged right. This change fixes that issue. It's worth noting this issue exists in source as well.

This makes the `\@tufte@justification@caption@outer` and `\@tufte@justification@outer` identical, hence they can be merged into one if desired, this requires change on line 250 to the second command.

Example of sample-handout.tex compiled before change with following options:
```latex
\documentclass[twoside,caption=raggedouter]{tufte-handout}
```
![Example of text alignment in caption with raggedouter option before fix](https://github.com/user-attachments/assets/f1d10e99-8e25-464d-b7a1-19576b408b16
"Example of text alignment in caption with raggedouter option before fix")

And here is an example of the same file compiled after the change, with same options:
![Example of text alignment in caption with raggedouter option after fix](https://github.com/user-attachments/assets/4913ecc8-9c5d-4798-a727-c80f9758f795
"Example of text alignment in caption with raggedouter option after fix")